### PR TITLE
98_FireTV.pm: rename PRESENCE internals

### DIFF
--- a/FHEM/98_FireTV.pm
+++ b/FHEM/98_FireTV.pm
@@ -123,8 +123,8 @@ sub FireTV_Define($$) {
     if($hash->{helper}{$name}{'PRESENCE_loaded'}) {
         # PRESENCE
         $hash->{NOTIFYDEV}          = "global,$name";
-        $hash->{TIMEOUT_NORMAL}     = $param[4] || 30;
-        $hash->{TIMEOUT_PRESENT}    = $param[5] || $hash->{TIMEOUT_NORMAL};
+        $hash->{INTERVAL_NORMAL}    = $param[4] || 30;
+        $hash->{INTERVAL_PRESENT}   = $param[5] || $hash->{INTERVAL_NORMAL};
         $hash->{MODE}               = $param[6] || 'lan-ping';
         $hash->{ADDRESS}            = $param[7] || $hash->{IP};
         


### PR DESCRIPTION
see https://forum.fhem.de/index.php/topic,83805.msg817958.html#msg817958 

renamed PRESENCE internals to avoid Perl warnings when using 98_FireTV.pm